### PR TITLE
Introduce 'navigationLocked' option to prevent iframe errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ module.exports = {
         // raise or lower this limit if you wish.
         maxAttempts: 10,
 
+        // Prevent PhantomJS from navigating away from the URL passed to it
+        // and prevent from loading embedded <iframes>, which are not ideal
+        // for SEO and may introduce JS errors (Disqus, Soundcloud, etc embeds)
+        navigationLocked: true,
+
         // The options below expose configuration options for PhantomJS,
         // for the rare case that you need special settings for specific
         // systems or applications.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ module.exports = {
         maxAttempts: 10,
 
         // Prevent PhantomJS from navigating away from the URL passed to it
-        // and prevent from loading embedded <iframes>, which are not ideal
-        // for SEO and may introduce JS errors (Disqus, Soundcloud, etc embeds)
+        // and prevent loading embedded iframes (e.g. Disqus and Soundcloud
+        // embeds), which are not ideal for SEO and may introduce JS errors.
         navigationLocked: true,
 
         // The options below expose configuration options for PhantomJS,

--- a/lib/phantom-page-render.js
+++ b/lib/phantom-page-render.js
@@ -14,6 +14,13 @@ page.onResourceRequested = function (requestData, request) {
   if (/\.css$/i.test(requestData.url)) request.abort()
 }
 
+// PREVENT <iframe> LOADS & UNWANTED NAVIGATION AWAY FROM PAGE
+if (options.navigationLocked) {
+  page.onLoadStarted = function () {
+    page.navigationLocked = true
+  }
+}
+
 if (options.phantomPageSettings) {
   page.settings = defaultsDeep(options.phantomPageSettings, page.settings)
 }


### PR DESCRIPTION
Thank you for writing this plugin!

I implemented it in a project for my personal website's blog section, which takes a big string of markdown, parses it, and appends the raw HTML. This raw HTML sometimes includes special `iframe` embeds, either directly in the page (Soundcloud Player embed) or asynchronously injected post-load (Disqus embed).

**Problem:** PhantomJS would spew out javascript error messages caused by the Soundcloud widget before the `<html>` tag, making some of my prerendered `index.html`'s unusable.

I researched this a bit and `iframe` loading can be suppressed with:

```
page.onLoadStarted = function () {
  page.navigationLocked = true
}
```

**Solution:** I've added `navigationLocked` as an option to the plugin.

I do not believe `page.navigationLocked` has any side effects. The behavior might be _more desirable in general_ because, by locking navigation, the primary URL can never change due to `<meta>` redirects or other tom foolery.

This option is not turned on by default. I will leave that up to you 🎱 