### PR TITLE
Fixed too low maxBuffer setting

### DIFF
--- a/lib/compile-to-html.js
+++ b/lib/compile-to-html.js
@@ -70,6 +70,7 @@ module.exports = function (staticDir, route, options, callback) {
             ChildProcess.execFile(
               Phantom.path,
               phantomArguments,
+              {maxBuffer: 1048576},
               function (error, stdout, stderr) {
                 if (error || stderr) {
                   // Retry if we haven't reached the max number of capture attempts


### PR DESCRIPTION
When phantom returns large pages, it runs out of buffer space.

Fix by setting to 1MiB.