### PR TITLE
Properly handle the end of plugin compilation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var FS = require('fs')
 var Path = require('path')
 var mkdirp = require('mkdirp')
+var asyncEach = require('async.each')
+
 var compileToHTML = require('./lib/compile-to-html')
 
 function SimpleHtmlPrecompiler (staticDir, paths, options) {
@@ -9,25 +11,38 @@ function SimpleHtmlPrecompiler (staticDir, paths, options) {
   this.options = options || {}
 }
 
+// High-order function that takes compilation context
+// and generates `iteratee` function (used by async.each).
+//
+// The output is asynchronous function used to compile
+// individual path.
+function compilePathFabric (compilation, context) {
+  return function (outputPath, done) {
+    compileToHTML(context.staticDir, outputPath, context.options, function (prerenderedHTML) {
+      var folder = Path.join(context.staticDir, outputPath)
+
+      mkdirp(folder, function (error) {
+        // In case of error propagate it back to compile
+        if (error) return done(error)
+
+        FS.writeFile(
+          Path.join(folder, 'index.html'),
+          prerenderedHTML,
+          function (error) {
+            done(error)
+          })
+      })
+    })
+  }
+}
+
 SimpleHtmlPrecompiler.prototype.apply = function (compiler) {
   var self = this
   compiler.plugin('emit', function (compilation, done) {
-    self.paths.forEach(function (outputPath) {
-      compileToHTML(self.staticDir, outputPath, self.options, function (prerenderedHTML) {
-        var folder = Path.join(self.staticDir, outputPath)
-        mkdirp(folder, function (error) {
-          if (error) throw error
-          FS.writeFile(
-            Path.join(folder, 'index.html'),
-            prerenderedHTML,
-            function (error) {
-              if (error) throw error
-            }
-          )
-        })
-      })
+    asyncEach(self.paths, compilePathFabric(compilation, self), function (error) {
+      if (error) throw error
+      done()
     })
-    done()
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Chris Fritz",
   "license": "MIT",
   "dependencies": {
+    "async.each": "^0.5.2",
     "hapi": "13.2.2",
     "inert": "3.2.0",
     "lodash": "^4.13.1",


### PR DESCRIPTION
Hey, we've been using the plugin in a several projects and I must admit it really helped us to boost our workflow! 👍🏻

However, I run into a weird issue when trying to run Webpack compilation using Node.js API. We're building a static site generator service and I needed to be able to build websites in a queue. The service is for internal-use only that's why I basically wait until the previous built is done and then schedule another one. And I've noticed that sometimes static files are not ready yet by the end of compilation. After some debugging it turned out that Phantom.js is still running even after plugin's callback has been called. 

So I took the example project to verify the bug:
```
# Current implementation
[Webpack Node.js] start webpack compilation...
[index.js] calling done()
[Webpack Node.js] compile callback called
[index.js] /: compileToHTML callback
[index.js] /about: compileToHTML callback
[index.js] /about: FS.writeFile callback
[index.js] /: FS.writeFile callback
```

Indeed, if you look at `index.js` file here is what happens:
```js
SimpleHtmlPrecompiler.prototype.apply = function (compiler) {
  var self = this
  compiler.plugin('emit', function (compilation, done) {
    self.paths.forEach(function (outputPath) {
      compileToHTML(self.staticDir, outputPath, self.options, function (prerenderedHTML) {
        var folder = Path.join(self.staticDir, outputPath)
        mkdirp(folder, function (error) {
          if (error) throw error
          FS.writeFile(
            Path.join(folder, 'index.html'),
            prerenderedHTML,
            function (error) {
              if (error) throw error
            }
          )
        })
      })
    })
    done()
  })
}
```
The `done()` is called right away, but there is a lot of things happening like calling phantom, file write etc. I have modified the code so that it waits until all paths are compiled. I use a modularized version of [async's](http://caolan.github.io/async/docs.html#each) `each` function and it shouldn't add a dependency overhead to the project.

Here is how it works after the patch:
```
[Webpack Node.js] start webpack compilation...
[index.js] /: compileToHTML callback
[index.js] /about: compileToHTML callback
[index.js] /about: FS.writeFile callback
[index.js] calling done()
[index.js] /: FS.writeFile callback
[Webpack Node.js] compile callback called
```

I presume that most of the people don't use the plugin with Node.js API, instead they use `webpack` command and because of the nature of Node.js it doesn't end the process when there are incomplete IO operations. That's why everything seemed to work 😀

Hope you like the idea. Please check the spelling and grammar in comments, I'm not the native speaker.

