### PR TITLE
Added ability to set phantom viewport dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,13 @@ module.exports = {
         phantomPageSettings: {
           loadImages: true
         },
-
+        
+        // http://phantomjs.org/api/webpage/property/viewport-size.html
+        phantomPageViewportSize: {
+          width: 1280,
+          height: 800
+        },
+        
         // Manually transform the HTML for each page after prerendering,
         // for example to set the page title and metadata in edge cases
         // where you cannot handle this via your routing solution.

--- a/lib/phantom-page-render.js
+++ b/lib/phantom-page-render.js
@@ -38,6 +38,10 @@ if (options.phantomPageSettings) {
   page.settings = defaultsDeep(options.phantomPageSettings, page.settings)
 }
 
+if (options.phantomPageViewportSize) {
+  page.viewportSize = options.phantomPageViewportSize
+}
+
 page.open(url, function (status) {
   if (status !== 'success') {
     throw new Error('FAIL to load: ' + url)


### PR DESCRIPTION
Define some more "standard" viewport size.

(I use this plugin to prerender a page containing divs sized after window' size)