### PR TITLE
Add option to webserver to serve hidden files

### DIFF
--- a/lib/compile-to-html.js
+++ b/lib/compile-to-html.js
@@ -42,7 +42,8 @@ module.exports = function (staticDir, route, options, callback) {
             directory: {
               path: '.',
               redirectToSlash: true,
-              index: true
+              index: true,
+              showHidden: true
             }
           }
         })


### PR DESCRIPTION
As we should work in local environment, this option gives to webserver the ability to serve files stored into hidden directories ('/.resources' for example).