### PR TITLE
Correctly throw error if PhantomJS fails

### DIFF
--- a/lib/compile-to-html.js
+++ b/lib/compile-to-html.js
@@ -79,7 +79,7 @@ module.exports = function (staticDir, route, options, callback) {
                   if (attemptsSoFar <= maxAttempts) {
                     return capturePage()
                   } else {
-                    if (error) throw stdout
+                    if (error) throw error
                     if (stderr) throw stderr
                   }
                 }


### PR DESCRIPTION
Seems like throwing `stdout` is a bug. I ran into a failure due to missing the ["secret dependency" for PhantomJS](https://github.com/ariya/phantomjs/issues/10904) but was getting no error output until I changed to throwing `error`.