### PR TITLE
Option to customize the name of the rendered .html file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ module.exports = {
         navigationLocked: true,
 
         // Specify the name of the rendered .html file
-        outputFile: 'index.html'
+        outputFile: 'index.html',
 
         // The options below expose configuration options for PhantomJS,
         // for the rare case that you need special settings for specific

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ module.exports = {
         // embeds), which are not ideal for SEO and may introduce JS errors.
         navigationLocked: true,
 
+        // Specify the name of the rendered .html file
+        outputFile: 'index.html'
+
         // The options below expose configuration options for PhantomJS,
         // for the rare case that you need special settings for specific
         // systems or applications.

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ SimpleHtmlPrecompiler.prototype.apply = function (compiler) {
               if (error) {
                 return reject('Folder could not be created: ' + folder + '\n' + error)
               }
-              var file = Path.join(folder, 'index.html')
+              var file = Path.join(folder, self.options.outputFile || 'index.html')
               FS.writeFile(
                 file,
                 prerenderedHTML,

--- a/lib/phantom-page-render.js
+++ b/lib/phantom-page-render.js
@@ -18,8 +18,6 @@ page.onResourceRequested = function (requestData, request) {
   if (/\.css$/i.test(requestData.url)) request.abort()
 }
 
-page.onInitilize
-
 page.onError = function (message, trace) {
   if (options.ignoreJSErrors) return
   var pathname = url.replace(/http:\/\/localhost:\d+/, '')


### PR DESCRIPTION
In certain cases, I need to render a file with a name other than `index.html`. This is a simple solution give the user the ability to customize the file name. If no file name is provided, it defaults to `index.html`.