### PR TITLE
Update webpack code splitting URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ module.exports = {
 
 ### Code Splitting
 
-If you're using [code splitting](https://webpack.github.io/docs/code-splitting.html), visits to some prerendered pages [might throw](https://github.com/chrisvfritz/prerender-spa-plugin/issues/9): `Uncaught ReferenceError: webpackJsonp is not defined`. That just means some asynchronous chunks that Webpack injects into `<head>` are being evaluated before your main scripts, often in `<body>`.
+If you're using [code splitting](https://webpack.js.org/guides/code-splitting/), visits to some prerendered pages [might throw](https://github.com/chrisvfritz/prerender-spa-plugin/issues/9): `Uncaught ReferenceError: webpackJsonp is not defined`. That just means some asynchronous chunks that Webpack injects into `<head>` are being evaluated before your main scripts, often in `<body>`.
 
 If you're using `html-webpack-plugin`, you can resolve this by also injecting your main scripts into `<head>` with these options:
 


### PR DESCRIPTION
Webpack documentation has been updated and the previous version deleted.