### PR TITLE
feat(errors): adds error handling that will terminate the node process.

### DIFF
--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -154,7 +154,8 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
     }).catch(function (err) {
       PrerendererInstance.destroy();
       console.error('[prerender-spa-plugin] Unable to prerender all routes!');
-      throw err;
+      compilation.errors.push(new Error('[prerender-spa-plugin] Unable to prerender all routes!'));
+      done();
     });
   };
 

--- a/es6/index.js
+++ b/es6/index.js
@@ -143,8 +143,9 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       })
       .catch(err => {
         PrerendererInstance.destroy()
-        console.error('[prerender-spa-plugin] Unable to prerender all routes!')
-        throw err
+        console.error('[prerender-spa-plugin] Unable to prerender all routes!');
+        compilation.errors.push( new Error( '[prerender-spa-plugin] Unable to prerender all routes!' ) );
+        done();
       })
   }
 


### PR DESCRIPTION
prior to this PR whenever the prerender plugin would fail and throw the error 
```
[prerender-spa-plugin] Unable to prerender all routes!
```
but the build would continue successfully. This caused big problems for CI/CD platforms that rely on the process to exit so the build process can fail.