### PR TITLE
Fixed empty file written to outputPath

### DIFF
--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -133,10 +133,8 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
         return mkdirp(path.dirname(processedRoute.outputPath)).then(function () {
           return new Promise(function (resolve, reject) {
             compilerFS.writeFile(processedRoute.outputPath, processedRoute.html.trim(), function (err) {
-              if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${processedRoute.outputPath}" \n ${err}.`);
+              if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${processedRoute.outputPath}" \n ${err}.`);else resolve();
             });
-
-            resolve();
           });
         }).catch(function (err) {
           if (typeof err === 'string') {
@@ -153,8 +151,9 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       done();
     }).catch(function (err) {
       PrerendererInstance.destroy();
-      console.error('[prerender-spa-plugin] Unable to prerender all routes!');
-      compilation.errors.push(new Error('[prerender-spa-plugin] Unable to prerender all routes!'));
+      var msg = '[prerender-spa-plugin] Unable to prerender all routes!';
+      console.error(msg);
+      compilation.errors.push(new Error(msg));
       done();
     });
   };

--- a/es6/index.js
+++ b/es6/index.js
@@ -143,9 +143,10 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       })
       .catch(err => {
         PrerendererInstance.destroy()
-        console.error('[prerender-spa-plugin] Unable to prerender all routes!');
-        compilation.errors.push( new Error( '[prerender-spa-plugin] Unable to prerender all routes!' ) );
-        done();
+        const msg = '[prerender-spa-plugin] Unable to prerender all routes!'
+        console.error(msg)
+        compilation.errors.push(new Error(msg))
+        done()
       })
   }
 

--- a/es6/index.js
+++ b/es6/index.js
@@ -121,9 +121,8 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
               return new Promise((resolve, reject) => {
                 compilerFS.writeFile(processedRoute.outputPath, processedRoute.html.trim(), err => {
                   if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${processedRoute.outputPath}" \n ${err}.`)
+                  else resolve()
                 })
-
-                resolve()
               })
             })
             .catch(err => {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
       "name": "Joshua Bemenderfer",
       "email": "tribex10@gmail.com",
       "url": "https://joshderf.com/"
+    },
+    {
+      "name": "qkdreyer",
+      "email": "quentin.dreyer@gmail.com"
     }
   ],
   "repository": "chrisvfritz/prerender-spa-plugin",


### PR DESCRIPTION
I'm not sure how this would have been correctly be working before, but compilerFS is https://github.com/webpack/webpack/blob/master/lib/node/NodeOutputFileSystem.js, and it's method writeFile is a binding to fs.writeFile, which is async.

We have to wait the compilerFS.writeFile callback to be called before resolving the promise.
Please merge this ASAP since it might fix #230