### PR TITLE
feat: allow postProcess to return a promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ In the interest of transparency, there are some use-cases where prerendering mig
 
 #### Using The postProcess Option
 
-The `postProcess(Object context): Object` function in your renderer configuration allows you to adjust the output of `prerender-spa-plugin` before writing it to a file. It is called once per rendered route and is passed a `context` object in the form of:
+The `postProcess(Object context): Object | Promise` function in your renderer configuration allows you to adjust the output of `prerender-spa-plugin` before writing it to a file. It is called once per rendered route and is passed a `context` object in the form of:
 
 ```javascript
 {
@@ -315,7 +315,7 @@ The `postProcess(Object context): Object` function in your renderer configuratio
 
 You can modify `context.html` to change what gets written to the prerendered files and/or modify `context.route` or `context.outputPath` to change the output location.
 
-You are expected to adjust those properties as needed, then return the context object, like so:
+You are expected to adjust those properties as needed, then return the context object, or a promise that resolves to it like so:
 
 ```javascript
 postProcess(context) {
@@ -326,6 +326,14 @@ postProcess(context) {
   }
 
   return context
+}
+
+postProcess(context) {
+  return someAsyncProcessing(context.html)
+    .then((html) => {
+      context.html = html;
+      return context;
+    });
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ In the interest of transparency, there are some use-cases where prerendering mig
 | staticDir | String | Yes | None | The root path to serve your app from. |
 | ouputDir | String | No | None | Where the prerendered pages should be output. If not set, defaults to staticDir. |
 | indexPath | String | No | `staticDir/index.html` | The index file to fall back on for SPAs. |
-| postProcess | Function(Object context): Object | No | None | See the [Using the postProcess Option](#using-the-postprocess-option) section. |
+| postProcess | Function(Object context): [Object \| Promise] | No | None | See the [Using the postProcess Option](#using-the-postprocess-option) section. |
 | minify | Object | No | None | Minifies the resulting HTML using [html-minifier](https://github.com/kangax/html-minifier). Full list of options available [here](https://github.com/kangax/html-minifier#options-quick-reference). |
 | server | Object | No | None | App server configuration options (See below) |
 | renderer | Renderer Instance or Configuration Object | No | `new PuppeteerRenderer()` | The renderer you'd like to use to prerender the app. It's recommended that you specify this, but if not it will default to `@prerenderer/renderer-puppeteer`. |

--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -83,18 +83,18 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
     })
     // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
     .then(function (renderedRoutes) {
-      return _this2._options.postProcessHtml ? renderedRoutes.map(function (renderedRoute) {
+      return _this2._options.postProcessHtml ? Promise.all(renderedRoutes.map(function (renderedRoute) {
         var processed = _this2._options.postProcessHtml(renderedRoute);
         if (typeof processed === 'string') renderedRoute.html = processed;else renderedRoute = processed;
 
         return renderedRoute;
-      }) : renderedRoutes;
+      })) : renderedRoutes;
     })
     // Run postProcess hooks.
     .then(function (renderedRoutes) {
-      return _this2._options.postProcess ? renderedRoutes.map(function (renderedRoute) {
+      return _this2._options.postProcess ? Promise.all(renderedRoutes.map(function (renderedRoute) {
         return _this2._options.postProcess(renderedRoute);
-      }) : renderedRoutes;
+      })) : renderedRoutes;
     })
     // Check to ensure postProcess hooks returned the renderedRoute object properly.
     .then(function (renderedRoutes) {

--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -83,12 +83,12 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
     })
     // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
     .then(function (renderedRoutes) {
-      return _this2._options.postProcessHtml ? Promise.all(renderedRoutes.map(function (renderedRoute) {
+      return _this2._options.postProcessHtml ? renderedRoutes.map(function (renderedRoute) {
         var processed = _this2._options.postProcessHtml(renderedRoute);
         if (typeof processed === 'string') renderedRoute.html = processed;else renderedRoute = processed;
 
         return renderedRoute;
-      })) : renderedRoutes;
+      }) : renderedRoutes;
     })
     // Run postProcess hooks.
     .then(function (renderedRoutes) {

--- a/es6/index.js
+++ b/es6/index.js
@@ -70,18 +70,18 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       })
       // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
       .then(renderedRoutes => this._options.postProcessHtml
-        ? renderedRoutes.map(renderedRoute => {
+        ? Promise.all(renderedRoutes.map(renderedRoute => {
           const processed = this._options.postProcessHtml(renderedRoute)
           if (typeof processed === 'string') renderedRoute.html = processed
           else renderedRoute = processed
 
           return renderedRoute
-        })
+        }))
         : renderedRoutes
       )
       // Run postProcess hooks.
       .then(renderedRoutes => this._options.postProcess
-        ? renderedRoutes.map(renderedRoute => this._options.postProcess(renderedRoute))
+        ? Promise.all(renderedRoutes.map(renderedRoute => this._options.postProcess(renderedRoute)))
         : renderedRoutes
       )
       // Check to ensure postProcess hooks returned the renderedRoute object properly.

--- a/es6/index.js
+++ b/es6/index.js
@@ -70,13 +70,13 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       })
       // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
       .then(renderedRoutes => this._options.postProcessHtml
-        ? Promise.all(renderedRoutes.map(renderedRoute => {
+        ? renderedRoutes.map(renderedRoute => {
           const processed = this._options.postProcessHtml(renderedRoute)
           if (typeof processed === 'string') renderedRoute.html = processed
           else renderedRoute = processed
 
           return renderedRoute
-        }))
+        })
         : renderedRoutes
       )
       // Run postProcess hooks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3156,12 +3156,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3176,17 +3178,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3303,7 +3308,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3315,6 +3321,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3329,6 +3336,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3336,12 +3344,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3360,6 +3370,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3440,7 +3451,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3452,6 +3464,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3573,6 +3586,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
Wrap `postProcess` calls inside a `Promise.all` in order to support async functions.

Fixes #240 