### PR TITLE
rewrite plugin code to support batching of routes during prerender

### DIFF
--- a/es5-autogenerated/index.js
+++ b/es5-autogenerated/index.js
@@ -1,5 +1,13 @@
 'use strict';
 
+var _regenerator = require('babel-runtime/regenerator');
+
+var _regenerator2 = _interopRequireDefault(_regenerator);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
 var path = require('path');
 var Prerenderer = require('@prerenderer/prerenderer');
 var PuppeteerRenderer = require('@prerenderer/renderer-puppeteer');
@@ -55,6 +63,7 @@ function PrerenderSPAPlugin() {
 
   this._options.server = this._options.server || {};
   this._options.renderer = this._options.renderer || new PuppeteerRenderer(Object.assign({}, { headless: true }, rendererOptions));
+  this._options.batchSize = this._options.batchSize || this._options.routes.length;
 
   if (this._options.postProcessHtml) {
     console.warn('[prerender-spa-plugin] postProcessHtml should be migrated to postProcess! Consult the documentation for more information.');
@@ -75,91 +84,176 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
     });
   };
 
-  var afterEmit = function afterEmit(compilation, done) {
-    var PrerendererInstance = new Prerenderer(_this2._options);
+  var afterEmit = function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_regenerator2.default.mark(function _callee(context, compilation, done) {
+      var reportProgress, routes, numBatches, batchNumber, batch, PrerendererInstance, renderedRoutes, msg;
+      return _regenerator2.default.wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.prev = 0;
 
-    PrerendererInstance.initialize().then(function () {
-      return PrerendererInstance.renderRoutes(_this2._options.routes || []);
-    })
-    // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
-    .then(function (renderedRoutes) {
-      return _this2._options.postProcessHtml ? renderedRoutes.map(function (renderedRoute) {
-        var processed = _this2._options.postProcessHtml(renderedRoute);
-        if (typeof processed === 'string') renderedRoute.html = processed;else renderedRoute = processed;
+              reportProgress = context && context.reportProgress || function () {};
 
-        return renderedRoute;
-      }) : renderedRoutes;
-    })
-    // Run postProcess hooks.
-    .then(function (renderedRoutes) {
-      return _this2._options.postProcess ? Promise.all(renderedRoutes.map(function (renderedRoute) {
-        return _this2._options.postProcess(renderedRoute);
-      })) : renderedRoutes;
-    })
-    // Check to ensure postProcess hooks returned the renderedRoute object properly.
-    .then(function (renderedRoutes) {
-      var isValid = renderedRoutes.every(function (r) {
-        return typeof r === 'object';
-      });
-      if (!isValid) {
-        throw new Error('[prerender-spa-plugin] Rendered routes are empty, did you forget to return the `context` object in postProcess?');
-      }
+              routes = _this2._options.routes.slice();
+              numBatches = Math.ceil(routes.length / _this2._options.batchSize);
+              batchNumber = 1;
 
-      return renderedRoutes;
-    })
-    // Minify html files if specified in config.
-    .then(function (renderedRoutes) {
-      if (!_this2._options.minify) return renderedRoutes;
+            case 5:
+              if (!(routes.length > 0)) {
+                _context.next = 42;
+                break;
+              }
 
-      renderedRoutes.forEach(function (route) {
-        route.html = minify(route.html, _this2._options.minify);
-      });
+              batch = routes.splice(0, _this2._options.batchSize);
+              PrerendererInstance = new Prerenderer(_this2._options);
+              _context.prev = 8;
 
-      return renderedRoutes;
-    })
-    // Calculate outputPath if it hasn't been set already.
-    .then(function (renderedRoutes) {
-      renderedRoutes.forEach(function (rendered) {
-        if (!rendered.outputPath) {
-          rendered.outputPath = path.join(_this2._options.outputDir || _this2._options.staticDir, rendered.route, 'index.html');
-        }
-      });
+              reportProgress((batchNumber - 1) / numBatches, `starting batch ${batchNumber}/${numBatches}`);
 
-      return renderedRoutes;
-    })
-    // Create dirs and write prerendered files.
-    .then(function (processedRoutes) {
-      var promises = Promise.all(processedRoutes.map(function (processedRoute) {
-        return mkdirp(path.dirname(processedRoute.outputPath)).then(function () {
-          return new Promise(function (resolve, reject) {
-            compilerFS.writeFile(processedRoute.outputPath, processedRoute.html.trim(), function (err) {
-              if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${processedRoute.outputPath}" \n ${err}.`);else resolve();
-            });
-          });
-        }).catch(function (err) {
-          if (typeof err === 'string') {
-            err = `[prerender-spa-plugin] Unable to create directory ${path.dirname(processedRoute.outputPath)} for route ${processedRoute.route}. \n ${err}`;
+              _context.next = 12;
+              return PrerendererInstance.initialize();
+
+            case 12:
+
+              reportProgress(batchNumber / numBatches, `rendering batch ${batchNumber}/${numBatches}`);
+
+              _context.next = 15;
+              return PrerendererInstance.renderRoutes(batch || []);
+
+            case 15:
+              renderedRoutes = _context.sent;
+
+
+              // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
+              if (_this2._options.postProcessHtml) {
+                renderedRoutes = renderedRoutes.map(function (renderedRoute) {
+                  var processed = _this2._options.postProcessHtml(renderedRoute);
+                  if (typeof processed === 'string') renderedRoute.html = processed;else renderedRoute = processed;
+                  return renderedRoute;
+                });
+              }
+
+              // Run postProcess hooks.
+
+              if (!_this2._options.postProcess) {
+                _context.next = 21;
+                break;
+              }
+
+              _context.next = 20;
+              return Promise.all(renderedRoutes.map(function (renderedRoute) {
+                return _this2._options.postProcess(renderedRoute);
+              }));
+
+            case 20:
+              renderedRoutes = _context.sent;
+
+            case 21:
+              if (renderedRoutes.every(function (r) {
+                return typeof r === 'object';
+              })) {
+                _context.next = 23;
+                break;
+              }
+
+              throw new Error('[prerender-spa-plugin] Rendered routes are empty, did you forget to return the `context` object in postProcess?');
+
+            case 23:
+
+              // Minify html files if specified in config.
+              if (_this2._options.minify) {
+                renderedRoutes.forEach(function (route) {
+                  route.html = minify(route.html, _this2._options.minify);
+                });
+              }
+
+              // Calculate outputPath if it hasn't been set already.
+              renderedRoutes.forEach(function (rendered) {
+                if (!rendered.outputPath) {
+                  rendered.outputPath = path.join(_this2._options.outputDir || _this2._options.staticDir, rendered.route, 'index.html');
+                }
+              });
+
+              // Create dirs and write prerendered files.
+              reportProgress(batchNumber / (numBatches * 2), `writing batch ${batchNumber}/${numBatches}`);
+              _context.next = 28;
+              return Promise.all(renderedRoutes.map(function (route) {
+                return mkdirp(path.dirname(route.outputPath)).then(function () {
+                  return new Promise(function (resolve, reject) {
+                    compilerFS.writeFile(route.outputPath, route.html.trim(), function (err) {
+                      if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${route.outputPath}" \n ${err}.`);else resolve();
+                    });
+                  });
+                }).catch(function (err) {
+                  if (typeof err === 'string') {
+                    err = `[prerender-spa-plugin] Unable to create directory ${path.dirname(route.outputPath)} for route ${route.route}. \n ${err}`;
+                  }
+
+                  throw err;
+                });
+              }));
+
+            case 28:
+              _context.next = 30;
+              return PrerendererInstance.destroy();
+
+            case 30:
+              _context.next = 32;
+              return new Promise(function (resolve) {
+                return setTimeout(resolve, 250);
+              });
+
+            case 32:
+
+              ++batchNumber;
+              _context.next = 40;
+              break;
+
+            case 35:
+              _context.prev = 35;
+              _context.t0 = _context['catch'](8);
+              _context.next = 39;
+              return PrerendererInstance.destroy();
+
+            case 39:
+              throw _context.t0;
+
+            case 40:
+              _context.next = 5;
+              break;
+
+            case 42:
+              _context.next = 50;
+              break;
+
+            case 44:
+              _context.prev = 44;
+              _context.t1 = _context['catch'](0);
+              msg = '[prerender-spa-plugin] Unable to prerender all routes!';
+
+              console.error(msg);
+              console.error(_context.t1);
+              compilation.errors.push(new Error(msg));
+
+            case 50:
+              done();
+
+            case 51:
+            case 'end':
+              return _context.stop();
           }
+        }
+      }, _callee, _this2, [[0, 44], [8, 35]]);
+    }));
 
-          throw err;
-        });
-      }));
-
-      return promises;
-    }).then(function (r) {
-      PrerendererInstance.destroy();
-      done();
-    }).catch(function (err) {
-      PrerendererInstance.destroy();
-      var msg = '[prerender-spa-plugin] Unable to prerender all routes!';
-      console.error(msg);
-      compilation.errors.push(new Error(msg));
-      done();
-    });
-  };
+    return function afterEmit(_x, _x2, _x3) {
+      return _ref.apply(this, arguments);
+    };
+  }();
 
   if (compiler.hooks) {
-    var plugin = { name: 'PrerenderSPAPlugin' };
+    var plugin = { name: 'PrerenderSPAPlugin', context: true };
     compiler.hooks.afterEmit.tapAsync(plugin, afterEmit);
   } else {
     compiler.plugin('after-emit', afterEmit);

--- a/es6/index.js
+++ b/es6/index.js
@@ -163,6 +163,4 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
   }
 }
 
-PrerenderSPAPlugin.PuppeteerRenderer = PuppeteerRenderer
-
 module.exports = PrerenderSPAPlugin

--- a/es6/index.js
+++ b/es6/index.js
@@ -1,6 +1,5 @@
 const path = require('path')
 const Prerenderer = require('@prerenderer/prerenderer')
-const PuppeteerRenderer = require('@prerenderer/renderer-puppeteer')
 const { minify } = require('html-minifier')
 
 function PrerenderSPAPlugin (...args) {
@@ -44,7 +43,7 @@ function PrerenderSPAPlugin (...args) {
   }
 
   this._options.server = this._options.server || {}
-  this._options.renderer = this._options.renderer || new PuppeteerRenderer(Object.assign({}, { headless: true }, rendererOptions))
+  this._options.renderer = this._options.renderer
   this._options.batchSize = this._options.batchSize || this._options.routes.length
 
   if (this._options.postProcessHtml) {

--- a/es6/index.js
+++ b/es6/index.js
@@ -12,7 +12,7 @@ function PrerenderSPAPlugin (...args) {
   if (args.length === 1) {
     this._options = args[0] || {}
 
-  // Backwards-compatibility with v2
+    // Backwards-compatibility with v2
   } else {
     console.warn("[prerender-spa-plugin] You appear to be using the v2 argument-based configuration options. It's recommended that you migrate to the clearer object-based configuration system.\nCheck the documentation for more information.")
     let staticDir, routes
@@ -45,6 +45,7 @@ function PrerenderSPAPlugin (...args) {
 
   this._options.server = this._options.server || {}
   this._options.renderer = this._options.renderer || new PuppeteerRenderer(Object.assign({}, { headless: true }, rendererOptions))
+  this._options.batchSize = this._options.batchSize || this._options.routes.length
 
   if (this._options.postProcessHtml) {
     console.warn('[prerender-spa-plugin] postProcessHtml should be migrated to postProcess! Consult the documentation for more information.')
@@ -61,96 +62,102 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
     })
   }
 
-  const afterEmit = (compilation, done) => {
-    const PrerendererInstance = new Prerenderer(this._options)
+  const afterEmit = async (context, compilation, done) => {
+    try {
+      const reportProgress = (context && context.reportProgress) || (() => { })
+      const routes = this._options.routes.slice()
+      const numBatches = Math.ceil(routes.length / this._options.batchSize)
+      let batchNumber = 1
+      while (routes.length > 0) {
+        const batch = routes.splice(0, this._options.batchSize)
+        const PrerendererInstance = new Prerenderer(this._options)
 
-    PrerendererInstance.initialize()
-      .then(() => {
-        return PrerendererInstance.renderRoutes(this._options.routes || [])
-      })
-      // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
-      .then(renderedRoutes => this._options.postProcessHtml
-        ? renderedRoutes.map(renderedRoute => {
-          const processed = this._options.postProcessHtml(renderedRoute)
-          if (typeof processed === 'string') renderedRoute.html = processed
-          else renderedRoute = processed
+        try {
+          reportProgress((batchNumber - 1) / numBatches, `starting batch ${batchNumber}/${numBatches}`)
 
-          return renderedRoute
-        })
-        : renderedRoutes
-      )
-      // Run postProcess hooks.
-      .then(renderedRoutes => this._options.postProcess
-        ? Promise.all(renderedRoutes.map(renderedRoute => this._options.postProcess(renderedRoute)))
-        : renderedRoutes
-      )
-      // Check to ensure postProcess hooks returned the renderedRoute object properly.
-      .then(renderedRoutes => {
-        const isValid = renderedRoutes.every(r => typeof r === 'object')
-        if (!isValid) {
-          throw new Error('[prerender-spa-plugin] Rendered routes are empty, did you forget to return the `context` object in postProcess?')
-        }
+          await PrerendererInstance.initialize()
 
-        return renderedRoutes
-      })
-      // Minify html files if specified in config.
-      .then(renderedRoutes => {
-        if (!this._options.minify) return renderedRoutes
+          reportProgress(batchNumber / numBatches, `rendering batch ${batchNumber}/${numBatches}`)
 
-        renderedRoutes.forEach(route => {
-          route.html = minify(route.html, this._options.minify)
-        })
+          let renderedRoutes = await PrerendererInstance.renderRoutes(batch || [])
 
-        return renderedRoutes
-      })
-      // Calculate outputPath if it hasn't been set already.
-      .then(renderedRoutes => {
-        renderedRoutes.forEach(rendered => {
-          if (!rendered.outputPath) {
-            rendered.outputPath = path.join(this._options.outputDir || this._options.staticDir, rendered.route, 'index.html')
+          // Backwards-compatibility with v2 (postprocessHTML should be migrated to postProcess)
+          if (this._options.postProcessHtml) {
+            renderedRoutes = renderedRoutes.map(renderedRoute => {
+              const processed = this._options.postProcessHtml(renderedRoute)
+              if (typeof processed === 'string') renderedRoute.html = processed
+              else renderedRoute = processed
+              return renderedRoute
+            })
           }
-        })
 
-        return renderedRoutes
-      })
-      // Create dirs and write prerendered files.
-      .then(processedRoutes => {
-        const promises = Promise.all(processedRoutes.map(processedRoute => {
-          return mkdirp(path.dirname(processedRoute.outputPath))
-            .then(() => {
-              return new Promise((resolve, reject) => {
-                compilerFS.writeFile(processedRoute.outputPath, processedRoute.html.trim(), err => {
-                  if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${processedRoute.outputPath}" \n ${err}.`)
-                  else resolve()
+          // Run postProcess hooks.
+          if (this._options.postProcess) {
+            renderedRoutes = await Promise.all(renderedRoutes.map(renderedRoute => this._options.postProcess(renderedRoute)))
+          }
+
+          // Check to ensure postProcess hooks returned the renderedRoute object properly.
+          if (!renderedRoutes.every(r => typeof r === 'object')) {
+            throw new Error('[prerender-spa-plugin] Rendered routes are empty, did you forget to return the `context` object in postProcess?')
+          }
+
+          // Minify html files if specified in config.
+          if (this._options.minify) {
+            renderedRoutes.forEach(route => {
+              route.html = minify(route.html, this._options.minify)
+            })
+          }
+
+          // Calculate outputPath if it hasn't been set already.
+          renderedRoutes.forEach(rendered => {
+            if (!rendered.outputPath) {
+              rendered.outputPath = path.join(this._options.outputDir || this._options.staticDir, rendered.route, 'index.html')
+            }
+          })
+
+          // Create dirs and write prerendered files.
+          reportProgress((batchNumber) / (numBatches * 2), `writing batch ${batchNumber}/${numBatches}`)
+          await Promise.all(renderedRoutes.map(route => {
+            return mkdirp(path.dirname(route.outputPath))
+              .then(() => {
+                return new Promise((resolve, reject) => {
+                  compilerFS.writeFile(route.outputPath, route.html.trim(), err => {
+                    if (err) reject(`[prerender-spa-plugin] Unable to write rendered route to file "${route.outputPath}" \n ${err}.`)
+                    else resolve()
+                  })
                 })
               })
-            })
-            .catch(err => {
-              if (typeof err === 'string') {
-                err = `[prerender-spa-plugin] Unable to create directory ${path.dirname(processedRoute.outputPath)} for route ${processedRoute.route}. \n ${err}`
-              }
+              .catch(err => {
+                if (typeof err === 'string') {
+                  err = `[prerender-spa-plugin] Unable to create directory ${path.dirname(route.outputPath)} for route ${route.route}. \n ${err}`
+                }
 
-              throw err
-            })
-        }))
+                throw err
+              })
+          }))
 
-        return promises
-      })
-      .then(r => {
-        PrerendererInstance.destroy()
-        done()
-      })
-      .catch(err => {
-        PrerendererInstance.destroy()
-        const msg = '[prerender-spa-plugin] Unable to prerender all routes!'
-        console.error(msg)
-        compilation.errors.push(new Error(msg))
-        done()
-      })
+          await PrerendererInstance.destroy()
+
+          // small time padding to allow system to fully free server resources
+          await new Promise(resolve => setTimeout(resolve, 250))
+
+          ++batchNumber
+        } catch (err) {
+          await PrerendererInstance.destroy()
+          throw err
+        }
+      }
+    } catch (err) {
+      const msg = '[prerender-spa-plugin] Unable to prerender all routes!'
+      console.error(msg)
+      console.error(err)
+      compilation.errors.push(new Error(msg))
+    }
+    done()
   }
 
   if (compiler.hooks) {
-    const plugin = { name: 'PrerenderSPAPlugin' }
+    const plugin = { name: 'PrerenderSPAPlugin', context: true }
     compiler.hooks.afterEmit.tapAsync(plugin, afterEmit)
   } else {
     compiler.plugin('after-emit', afterEmit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3135,7 +3135,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3550,7 +3551,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3606,6 +3608,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3649,12 +3652,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@prerenderer/prerenderer": "^0.7.2",
-    "@prerenderer/renderer-puppeteer": "^0.2.0",
     "html-minifier": "^3.5.16"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to an as yet unsolved memory leak/issue related to the underlying node server used by `prerenderer`, the plugin code has been updated to support a new `batchSize` option