### PR TITLE
Add details to generic error message 'unable to prerender all routes'

### DIFF
--- a/es6/index.js
+++ b/es6/index.js
@@ -142,7 +142,7 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
       })
       .catch(err => {
         PrerendererInstance.destroy()
-        const msg = '[prerender-spa-plugin] Unable to prerender all routes!'
+        const msg = '[prerender-spa-plugin] Unable to prerender all routes! ' + err
         console.error(msg)
         compilation.errors.push(new Error(msg))
         done()


### PR DESCRIPTION
This is a common error message that lack any detail. This PR adds the available context information to the error output.
Googling "unable to prerender all routes" shows that this is a common problem users face.

Output before PR:

> ERROR in [prerender-spa-plugin] Unable to prerender all routes!

Output with this PR:

> ERROR in [prerender-spa-plugin] Unable to prerender all routes! TypeError: compilerFS.mkdirp is not a function

(example from this unrelated issue #414)
