### PR TITLE
Fix: Not compatible with Webpack5, because of compilerFS.mkdirp was not supported now

### DIFF
--- a/es6/index.js
+++ b/es6/index.js
@@ -55,9 +55,13 @@ PrerenderSPAPlugin.prototype.apply = function (compiler) {
   const compilerFS = compiler.outputFileSystem
 
   // From https://github.com/ahmadnassri/mkdirp-promise/blob/master/lib/index.js
-  const mkdirp = function (dir, opts) {
+  const mkdirp = function (dir, opts = {}) {
     return new Promise((resolve, reject) => {
-      compilerFS.mkdirp(dir, opts, (err, made) => err === null ? resolve(made) : reject(err))
+      // webpack5: mkdirp is no longer expected to be a function on the output file system
+      // https://github.com/webpack/webpack.js.org/issues/3110
+      // Since Node 10, fs.mkdir(path[, options], callback) supporting mkdir recursively
+      opts.recursive = true
+      fs.mkdir(dir, opts, (err, made) => err === null ? resolve(made) : reject(err))
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "eslint-plugin-standard": "^1.3.3"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   }
 }


### PR DESCRIPTION
webpack5: mkdirp is no longer expected to be a function on the output file system
https://github.com/webpack/webpack.js.org/issues/3110

Since Node 10, fs.mkdir(path[, options], callback) supporting mkdir recursively.
Upgrade the `engines. node to` to `>=10.0.0`